### PR TITLE
use dropView(IfExists) for dropping views

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ You may drop many views at once by passing multiple view names:
 ```php
 use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
 
-Schema::dropExtension('myview1', 'myview2');
-Schema::dropExtensionIfExists('myview1', 'myview2');
+Schema::dropView('myview1', 'myview2');
+Schema::dropViewIfExists('myview1', 'myview2');
 ```
 
 ### Indexes


### PR DESCRIPTION
Currently the README.md states to use `dropExtension` or `dropExtensionIfExists` to drop multiple views. 

i changed it to `dropView` and `dropViewIfExists`. 

_IMHO_ it seems to be a copy-paste error.