### PR TITLE
feat: support deleteReturning in RefreshDataOnSave trait

### DIFF
--- a/src/Eloquent/Concerns/RefreshDataOnSave.php
+++ b/src/Eloquent/Concerns/RefreshDataOnSave.php
@@ -84,4 +84,20 @@ trait RefreshDataOnSave
 
         return true;
     }
+
+    /**
+     * Perform the actual delete query on this model instance.
+     *
+     * @return void
+     */
+    protected function performDeleteOnModel()
+    {
+        $returning = $this->setKeysForSaveQuery($this->newModelQuery())->deleteReturning();
+
+        if ($returning) {
+            $this->setRawAttributes((array) $returning->first());
+        } else {
+            $this->exists = false;
+        }
+    }
 }


### PR DESCRIPTION
I have a use case where I use a trigger to prevent the deletion of a row in case a certain condition is met. This PR enhances the `RefreshDataOnSave` trait in way that it uses the existing `deleteReturning` functionality and only marks the instance as deleted in case it was really deleted.