### PR TITLE
fix: implement base contract

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace Tpetry\PostgresqlEnhanced\Query;
 
 use Illuminate\Database\Query\Builder as BaseBuilder;
+use \Illuminate\Contracts\Database\Eloquent\Builder as BaseContract;
 use Tpetry\PostgresqlEnhanced\PostgresEnhancedConnection;
 
 /**
  * @method PostgresEnhancedConnection getConnection()
  * @method Grammar getGrammar()
  */
-class Builder extends BaseBuilder
+class Builder extends BaseBuilder implements BaseContract
 {
     use BuilderExplain;
     use BuilderLateralJoin;


### PR DESCRIPTION
Occasionally I see this error when I type my arguments:
```
Argument #1 ($builder) must be of type Illuminate\Contracts\Database\Eloquent\Builder, Tpetry\PostgresqlEnhanced\Query\Builder given
```

I think this change should not have any side effects.