### PR TITLE
Allow functional CTE definition

### DIFF
--- a/src/Query/GrammarCte.php
+++ b/src/Query/GrammarCte.php
@@ -18,7 +18,7 @@ trait GrammarCte
         foreach ($expressions as $expression) {
             $parts = [
                 transform($expression['options']['recursive'] ?? null, fn ($recursive) => $recursive ? 'recursive' : 'null'),
-                $this->wrapTable($expression['as']),
+                $this->escapeFunctionalCtes($expression['as']),
                 'as',
                 transform($expression['options']['materialized'] ?? null, fn ($materialized) => $materialized ? 'materialized' : 'not materialized'),
                 "({$expression['query']})",


### PR DESCRIPTION
Hello,

Thanks a lot for all the twitter tips, the great digital book and this package, they really helped me a lot!

I was wondering if you would allow to define recursive CTE that are functions.

I actually have a valid use case for this: i have to get distinct ids on millions of rows in a quick way and the best way to do it was with an example i found [here](https://explainextended.com/2009/05/03/postgresql-optimizing-distinct/).
Postgres doesn't have the best DISTINCT implementation so that is the best i could find.
A comment of this post explain how it can be done with a CTE:
```
WITH RECURSIVE t(n) AS (
  SELECT MIN(grouper) FROM t_distinct
  UNION ALL
  SELECT (
    SELECT t_distinct.grouper 
    FROM t_distinct
    WHERE t_distinct.grouper > n
    ORDER BY t_distinct.grouper
    LIMIT 1
  )
  FROM t WHERE n IS NOT NULL
)
SELECT n FROM t;
```

If you have an alternative, or improvements i would love to here it but that is not why i'm here today!

My issue is that the whole CTE name is wraped when it is declared but i would need to wrap the function name and the arguments separately.

It can be done in a more compact way but i wanted it to be as clear as possible.

Thank you for your time.