### PR TITLE
IDE Builder and Blueprint completions with ide.json

### DIFF
--- a/ide.json
+++ b/ide.json
@@ -17,6 +17,14 @@
             {
                 "classFqn": "Illuminate\\Database\\Schema\\ColumnDefinition",
                 "mixinFqn": "Tpetry\\PostgresqlEnhanced\\Schema\\ColumnDefinition"
+            },
+            {
+                "classFqn": "Illuminate\\Database\\Schema\\IndexDefinition",
+                "mixinFqn": "Tpetry\\PostgresqlEnhanced\\Schema\\IndexDefinition"
+            },
+            {
+                "classFqn": "Illuminate\\Support\\Facades\\Schema",
+                "mixinFqn": "Tpetry\\PostgresqlEnhanced\\Support\\Facades\\Schema"
             }
         ]
     }

--- a/ide.json
+++ b/ide.json
@@ -3,6 +3,10 @@
     "helperCode": {
         "classMixins": [
             {
+                "classFqn": "Illuminate\\Contracts\\Database\\Query\\Builder",
+                "mixinFqn": "Tpetry\\PostgresqlEnhanced\\Query\\Builder"
+            },
+            {
                 "classFqn": "Illuminate\\Database\\Query\\Builder",
                 "mixinFqn": "Tpetry\\PostgresqlEnhanced\\Query\\Builder"
             },

--- a/ide.json
+++ b/ide.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://laravel-ide.com/schema/laravel-ide-v2.json",
+    "helperCode": {
+        "classMixins": [
+            {
+                "classFqn": "Illuminate\\Database\\Query\\Builder",
+                "mixinFqn": "Tpetry\\PostgresqlEnhanced\\Query\\Builder"
+            },
+            {
+                "classFqn": "Illuminate\\Database\\Schema\\Blueprint",
+                "mixinFqn": "Tpetry\\PostgresqlEnhanced\\Schema\\Blueprint"
+            }
+        ]
+    }
+}

--- a/ide.json
+++ b/ide.json
@@ -13,6 +13,10 @@
             {
                 "classFqn": "Illuminate\\Database\\Schema\\Blueprint",
                 "mixinFqn": "Tpetry\\PostgresqlEnhanced\\Schema\\Blueprint"
+            },
+            {
+                "classFqn": "Illuminate\\Database\\Schema\\ColumnDefinition",
+                "mixinFqn": "Tpetry\\PostgresqlEnhanced\\Schema\\ColumnDefinition"
             }
         ]
     }

--- a/src/Schema/ColumnDefinition.php
+++ b/src/Schema/ColumnDefinition.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tpetry\PostgresqlEnhanced\Schema;
+
+use Illuminate\Contracts\Database\Query\Expression;
+use Illuminate\Database\Schema\ColumnDefinition as BaseColumnDefinition;
+
+/**
+ * @internal This class is not used. It only exists to teach Laravel projects using PHPStan or IDEs supporting auto-suggest about added functionality.
+ */
+class ColumnDefinition extends BaseColumnDefinition
+{
+    /**
+     * Specify the compression method for TOASTed values (PostgreSQL).
+     */
+    public function compression(string $algorithm): static
+    {
+        return $this;
+    }
+
+    /**
+     * Sets an initial value to the column (PostgreSQL).
+     */
+    public function initial(mixed $value): static
+    {
+        return $this;
+    }
+
+    /**
+     * Specify casting expression when changing the column type (PostgreSQL).
+     */
+    public function using(string|Expression $expression): static
+    {
+        return $this;
+    }
+}

--- a/src/Schema/ColumnDefinition.php
+++ b/src/Schema/ColumnDefinition.php
@@ -15,7 +15,7 @@ class ColumnDefinition extends BaseColumnDefinition
     /**
      * Specify the compression method for TOASTed values (PostgreSQL).
      */
-    public function compression(string $algorithm): static
+    public function compression(string $algorithm): self
     {
         return $this;
     }
@@ -23,7 +23,7 @@ class ColumnDefinition extends BaseColumnDefinition
     /**
      * Sets an initial value to the column (PostgreSQL).
      */
-    public function initial(mixed $value): static
+    public function initial(mixed $value): self
     {
         return $this;
     }
@@ -31,7 +31,7 @@ class ColumnDefinition extends BaseColumnDefinition
     /**
      * Specify casting expression when changing the column type (PostgreSQL).
      */
-    public function using(string|Expression $expression): static
+    public function using(string|Expression $expression): self
     {
         return $this;
     }

--- a/src/Schema/IndexDefinition.php
+++ b/src/Schema/IndexDefinition.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tpetry\PostgresqlEnhanced\Schema;
+
+use Illuminate\Database\Schema\IndexDefinition as BaseIndexDefinition;
+
+/**
+ * @internal This class is not used. It only exists to teach Laravel projects using PHPStan or IDEs supporting auto-suggest about added functionality.
+ */
+class IndexDefinition extends BaseIndexDefinition
+{
+    /**
+     * Include non-key columns in the index (PostgreSQL).
+     *
+     * @param string|array<int, string> $columns
+     */
+    public function include(string|array $columns): self
+    {
+        return $this;
+    }
+
+    /**
+     * Mark NULLs as not distinct values (PostgreSQL).
+     */
+    public function nullsNotDistinct(): self
+    {
+        return $this;
+    }
+
+    /**
+     * Specify fulltext index weight for columns (PostgreSQL).
+     *
+     * @param array<int, string> $labels
+     */
+    public function weight(array $labels): self
+    {
+        return $this;
+    }
+
+    /**
+     * Build a partial index by specifying the rows that should be included (PostgreSQL).
+     *
+     * @param string|(callable(\Illuminate\Database\Query\Builder):mixed)|(callable(\Illuminate\Contracts\Database\Query\Builder):mixed) $columns
+     */
+    public function where(string|callable $columns): self
+    {
+        return $this;
+    }
+
+    /**
+     * Specify index parameters to fine-tune its configuration (PostgreSQL).
+     *
+     * @param array<string, bool|float|int|string> $options
+     */
+    public function with(array $options): self
+    {
+        return $this;
+    }
+}

--- a/src/Support/Phpstan/SchemaColumnDefinitionExtension.php
+++ b/src/Support/Phpstan/SchemaColumnDefinitionExtension.php
@@ -4,83 +4,31 @@ declare(strict_types=1);
 
 namespace Tpetry\PostgresqlEnhanced\Support\Phpstan;
 
-use Illuminate\Contracts\Database\Query\Expression as ExpressionContract;
-use Illuminate\Database\Schema\ColumnDefinition;
+use Illuminate\Database\Schema\ColumnDefinition as BaseColumnDefinition;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\FunctionVariant;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
-use PHPStan\Type\Generic\TemplateTypeMap;
-use PHPStan\Type\MixedType;
-use PHPStan\Type\ObjectType;
-use PHPStan\Type\StringType;
-use Tpetry\PostgresqlEnhanced\Support\Phpstan\Values\ReflectedMethod;
-use Tpetry\PostgresqlEnhanced\Support\Phpstan\Values\ReflectedParameter;
+use PHPStan\Reflection\ReflectionProvider;
+use Tpetry\PostgresqlEnhanced\Schema\ColumnDefinition;
 
 class SchemaColumnDefinitionExtension implements MethodsClassReflectionExtension
 {
-    /**
-     * @param 'compression'|'initial'|'using' $methodName
-     */
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
     public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
     {
-        return match ($methodName) {
-            'initial' => $this->getInitialMethod($classReflection),
-            'compression' => $this->getCompressionMethod($classReflection),
-            'using' => $this->getUsingMethod($classReflection),
-        };
+        return $this->reflectionProvider->getClass(ColumnDefinition::class)->getNativeMethod($methodName);
     }
 
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
     {
-        if (ColumnDefinition::class !== $classReflection->getName()) {
+        if (BaseColumnDefinition::class !== $classReflection->getName()) {
             return false;
         }
 
-        return \in_array($methodName, ['compression', 'initial', 'using']);
-    }
-
-    private function getCompressionMethod(ClassReflection $classReflection): MethodReflection
-    {
-        $parameters = [new ReflectedParameter('algorithm', new StringType())];
-        $returnType = new ObjectType(ColumnDefinition::class);
-
-        return new ReflectedMethod(
-            classReflection: $classReflection,
-            name: 'compression',
-            variants: [
-                new FunctionVariant(TemplateTypeMap::createEmpty(), null, $parameters, false, $returnType),
-            ],
-        );
-    }
-
-    private function getInitialMethod(ClassReflection $classReflection): MethodReflection
-    {
-        $parameters = [new ReflectedParameter('value', new MixedType())];
-        $returnType = new ObjectType(ColumnDefinition::class);
-
-        return new ReflectedMethod(
-            classReflection: $classReflection,
-            name: 'initial',
-            variants: [
-                new FunctionVariant(TemplateTypeMap::createEmpty(), null, $parameters, false, $returnType),
-            ],
-        );
-    }
-
-    private function getUsingMethod(ClassReflection $classReflection): MethodReflection
-    {
-        $parametersExpression = [new ReflectedParameter('expression', new ObjectType(ExpressionContract::class))];
-        $parametersString = [new ReflectedParameter('expression', new StringType())];
-        $returnType = new ObjectType(ColumnDefinition::class);
-
-        return new ReflectedMethod(
-            classReflection: $classReflection,
-            name: 'using',
-            variants: [
-                new FunctionVariant(TemplateTypeMap::createEmpty(), null, $parametersExpression, false, $returnType),
-                new FunctionVariant(TemplateTypeMap::createEmpty(), null, $parametersString, false, $returnType),
-            ],
-        );
+        return $this->reflectionProvider->getClass(ColumnDefinition::class)->hasNativeMethod($methodName);
     }
 }


### PR DESCRIPTION
Hey. As promised, ide.json with new completions. I added only for Builder and Blueprint, maybe you will add some more.

It just adds `/** @mixin YourBuilder */ class DatabaseBuilder{}` during Laravwl Idea's Helper Code generation
So, PhpStorm will complete this class methods.

P.S. If you try to edit the ide.json file inside the vendor directory, Laravel Idea won't automatically load the changes. So, you will need to Laravel Idea Code Generation > Update ide.json metadata to load all changes:

<img width="452" alt="image" src="https://github.com/tpetry/laravel-postgresql-enhanced/assets/2818394/b3075c46-97b3-4ec9-8912-77631d8744fb">

It's only for your editing) users will fetch this file and all changes will be loaded automatically. They will need only  to generate the helper file.