### PR TITLE
fix: set table prefix on query grammar

### DIFF
--- a/src/PostgresEnhancedConnection.php
+++ b/src/PostgresEnhancedConnection.php
@@ -117,12 +117,11 @@ class PostgresEnhancedConnection extends PostgresConnection
     protected function getDefaultQueryGrammar(): QueryGrammar
     {
         $grammar = new QueryGrammar();
-        $grammar->setTablePrefix($this->tablePrefix);
         if (method_exists($grammar, 'setConnection')) {
             $grammar->setConnection($this);
         }
 
-        return $grammar;
+        return $this->withTablePrefix($grammar);
     }
 
     /**
@@ -131,12 +130,11 @@ class PostgresEnhancedConnection extends PostgresConnection
     protected function getDefaultSchemaGrammar(): SchemaGrammar
     {
         $grammar = new SchemaGrammar();
-        $grammar->setTablePrefix($this->tablePrefix);
         if (method_exists($grammar, 'setConnection')) {
             $grammar->setConnection($this);
         }
 
-        return $grammar;
+        return $this->withTablePrefix($grammar);
     }
 
     /**

--- a/src/PostgresEnhancedConnection.php
+++ b/src/PostgresEnhancedConnection.php
@@ -117,11 +117,12 @@ class PostgresEnhancedConnection extends PostgresConnection
     protected function getDefaultQueryGrammar(): QueryGrammar
     {
         $grammar = new QueryGrammar();
+        $grammar->setTablePrefix($this->tablePrefix);
         if (method_exists($grammar, 'setConnection')) {
             $grammar->setConnection($this);
         }
 
-        return $this->withTablePrefix($grammar);
+        return $grammar;
     }
 
     /**
@@ -130,11 +131,12 @@ class PostgresEnhancedConnection extends PostgresConnection
     protected function getDefaultSchemaGrammar(): SchemaGrammar
     {
         $grammar = new SchemaGrammar();
+        $grammar->setTablePrefix($this->tablePrefix);
         if (method_exists($grammar, 'setConnection')) {
             $grammar->setConnection($this);
         }
 
-        return $this->withTablePrefix($grammar);
+        return $grammar;
     }
 
     /**

--- a/src/PostgresEnhancedConnection.php
+++ b/src/PostgresEnhancedConnection.php
@@ -117,6 +117,7 @@ class PostgresEnhancedConnection extends PostgresConnection
     protected function getDefaultQueryGrammar(): QueryGrammar
     {
         $grammar = new QueryGrammar();
+        $grammar->setTablePrefix($this->tablePrefix);
         if (method_exists($grammar, 'setConnection')) {
             $grammar->setConnection($this);
         }


### PR DESCRIPTION
Using a `table_prefix` only works in migrations, and not in other queries.

Looks like we're missing a `setTablePrefix` here.