### PR TITLE
fix: use actual namespace instead of alias

### DIFF
--- a/src/Schema/Grammars/GrammarTable.php
+++ b/src/Schema/Grammars/GrammarTable.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tpetry\PostgresqlEnhanced\Schema\Grammars;
 
-use Arr;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Fluent;
 
 trait GrammarTable


### PR DESCRIPTION
When aliases are disabled in a Laravel project, we have to specify the entire FQCN. Third-parties that use aliases will cause errors, which this package did when we tried to update it.