### PR TITLE
fix: compatability to Laravel 11.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Schema::createFunction(
 A sixth parameter lets you define further options for the function. Please [read the manual](https://www.postgresql.org/docs/current/sql-createfunction.html) for the exact meaning, some of them set enable or disable ways for PostgreSQL to optimize the execution.
 
 | Option         | Values                            | Description                                                                                                    |
-| -------------- | --------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+|----------------|-----------------------------------|----------------------------------------------------------------------------------------------------------------|
 | `calledOnNull` | bool                              | Defines whether the function should be called for NULL values.                                                 |
 | `cost`         | integer                           | Defines the cost for executing the function.                                                                   |
 | `leakproof`    | bool                              | Informs whether the function has side effects.                                                                 |
@@ -254,7 +254,7 @@ Schema::table('projects', function (Blueprint $table): void {
 The following table contains all of the available trigger modifiers:
 
 | Modifier                                                                          | Description                                                                                                                                                        |
-| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|-----------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `->forEachRow()`                                                                  | The trigger will be called for every row.                                                                                                                          |
 | `->forEachStatement()`                                                            | The trigger will be called once for each statement *(default)*.                                                                                                    |
 | `->transitionTables(`<br>`  old: 'oldrows',`<br>`  new: 'newrows',`<br>`)`        | The forEachStatement-trigger will provide the before/after state of the affected rows in special tables. You can omit either option if not valid for this trigger. |
@@ -1018,7 +1018,7 @@ User::query()
 In addition to the basic form of a Common Table Expression these optional settings are available to support all PostgreSQL options:
 
 | Option       | Type     | Description                                                                                                                                                                                              |
-| ------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|--------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | materialized | `bool`   | Whether the CTE should be (not) materialized. This overrides PostgreSQL's automatic materialization decision. [(Documentation)](https://www.postgresql.org/docs/current/queries-with.html#id-1.5.6.12.7) |
 | recursive    | `bool`   | Whether to use a recursive CTE. [(Documentation)](https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-RECURSIVE)                                                                      |
 | cycle        | `string` | Specify the automatic cycle detection settings for recursive queries. [(Documentation)](https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-CYCLE)                                    |

--- a/README.md
+++ b/README.md
@@ -1103,7 +1103,7 @@ $query->orWhereNotBoolean($column, bool $value);
 
 #### Like
 
-With the `whereLike` scope you can compare a column to a (case-sensitive) value. 
+With the `whereLike` scope you can do case-(in)sensitive like comparisons between a column and a value. 
 
 ```php
 $query->whereLike($column, $value, $caseSensitive = false);

--- a/README.md
+++ b/README.md
@@ -1170,7 +1170,7 @@ Some of the PostgreSQL types are represented in a string format that a Laravel a
 To make those types usable, these casts can be used with your eloquent models:
 
 | Type           | Cast                                                        |
-| -------------- | ----------------------------------------------------------- |
+|----------------|-------------------------------------------------------------|
 | `integerArray` | `Tpetry\PostgresqlEnhanced\Eloquent\Casts\IntegerArrayCast` |
 | `vector`       | `Tpetry\PostgresqlEnhanced\Eloquent\Casts\VectorArray`      |
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Schema::createFunction(
 A sixth parameter lets you define further options for the function. Please [read the manual](https://www.postgresql.org/docs/current/sql-createfunction.html) for the exact meaning, some of them set enable or disable ways for PostgreSQL to optimize the execution.
 
 | Option         | Values                            | Description                                                                                                    |
-|----------------|-----------------------------------|----------------------------------------------------------------------------------------------------------------|
+| -------------- | --------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | `calledOnNull` | bool                              | Defines whether the function should be called for NULL values.                                                 |
 | `cost`         | integer                           | Defines the cost for executing the function.                                                                   |
 | `leakproof`    | bool                              | Informs whether the function has side effects.                                                                 |
@@ -254,7 +254,7 @@ Schema::table('projects', function (Blueprint $table): void {
 The following table contains all of the available trigger modifiers:
 
 | Modifier                                                                          | Description                                                                                                                                                        |
-|-----------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `->forEachRow()`                                                                  | The trigger will be called for every row.                                                                                                                          |
 | `->forEachStatement()`                                                            | The trigger will be called once for each statement *(default)*.                                                                                                    |
 | `->transitionTables(`<br>`  old: 'oldrows',`<br>`  new: 'newrows',`<br>`)`        | The forEachStatement-trigger will provide the before/after state of the affected rows in special tables. You can omit either option if not valid for this trigger. |
@@ -1018,7 +1018,7 @@ User::query()
 In addition to the basic form of a Common Table Expression these optional settings are available to support all PostgreSQL options:
 
 | Option       | Type     | Description                                                                                                                                                                                              |
-|--------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | materialized | `bool`   | Whether the CTE should be (not) materialized. This overrides PostgreSQL's automatic materialization decision. [(Documentation)](https://www.postgresql.org/docs/current/queries-with.html#id-1.5.6.12.7) |
 | recursive    | `bool`   | Whether to use a recursive CTE. [(Documentation)](https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-RECURSIVE)                                                                      |
 | cycle        | `string` | Specify the automatic cycle detection settings for recursive queries. [(Documentation)](https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-CYCLE)                                    |
@@ -1103,11 +1103,11 @@ $query->orWhereNotBoolean($column, bool $value);
 
 #### Like
 
-With the `whereLike` scope you can compare a column to a (case-insensitive) value. 
+With the `whereLike` scope you can compare a column to a (case-sensitive) value. 
 
 ```php
-$query->whereLike($column, $value, $caseInsensitive = false);
-$query->orWhereLike($column, $value, $caseInsensitive = false);
+$query->whereLike($column, $value, $caseSensitive = false);
+$query->orWhereLike($column, $value, $caseSensitive = false);
 ```
 
 #### Between Symmetric
@@ -1170,7 +1170,7 @@ Some of the PostgreSQL types are represented in a string format that a Laravel a
 To make those types usable, these casts can be used with your eloquent models:
 
 | Type           | Cast                                                        |
-|----------------|-------------------------------------------------------------|
+| -------------- | ----------------------------------------------------------- |
 | `integerArray` | `Tpetry\PostgresqlEnhanced\Eloquent\Casts\IntegerArrayCast` |
 | `vector`       | `Tpetry\PostgresqlEnhanced\Eloquent\Casts\VectorArray`      |
 

--- a/src/Query/BuilderWhere.php
+++ b/src/Query/BuilderWhere.php
@@ -63,6 +63,7 @@ trait BuilderWhere
      *
      * @param Expression|string $column
      * @param Expression|string $value
+     * @param bool $caseSensitive
      */
     public function orWhereLike($column, $value, $caseSensitive = false): static
     {
@@ -181,7 +182,9 @@ trait BuilderWhere
      *
      * @param Expression|string $column
      * @param Expression|string $value
+     * @param bool $caseSensitive
      * @param string $boolean
+     * @param bool $not
      */
     public function whereLike($column, $value, $caseSensitive = false, $boolean = 'and', $not = false): static
     {

--- a/src/Query/BuilderWhere.php
+++ b/src/Query/BuilderWhere.php
@@ -64,9 +64,9 @@ trait BuilderWhere
      * @param Expression|string $column
      * @param Expression|string $value
      */
-    public function orWhereLike($column, $value, bool $caseInsensitive = false): static
+    public function orWhereLike($column, $value, $caseSensitive = false): static
     {
-        return $this->whereLike($column, $value, $caseInsensitive, 'or');
+        return $this->whereLike($column, $value, $caseSensitive, 'or', false);
     }
 
     /**
@@ -183,11 +183,11 @@ trait BuilderWhere
      * @param Expression|string $value
      * @param string $boolean
      */
-    public function whereLike($column, $value, bool $caseInsensitive = false, $boolean = 'and'): static
+    public function whereLike($column, $value, $caseSensitive = false, $boolean = 'and', $not = false): static
     {
         $type = 'like';
 
-        $this->wheres[] = compact('type', 'column', 'value', 'caseInsensitive', 'boolean');
+        $this->wheres[] = compact('type', 'column', 'value', 'caseSensitive', 'boolean', 'not');
         $this->addBinding($value);
 
         return $this;

--- a/src/Query/GrammarWhere.php
+++ b/src/Query/GrammarWhere.php
@@ -50,10 +50,10 @@ trait GrammarWhere
      */
     public function whereLike(Builder $query, $where): string
     {
-        $where['operator'] = $where['not'] ? 'not ' : '';
-        $where['operator'] .= $where['caseSensitive'] ? 'like' : 'ilike';
-
-        return "{$this->wrap($where['column'])} {$where['operator']} {$this->parameter($where['value'])}";
+        return match ($where['caseSensitive']) {
+            true => "{$this->wrap($where['column'])} like {$this->parameter($where['value'])}",
+            false => "{$this->wrap($where['column'])} ilike {$this->parameter($where['value'])}",
+        };
     }
 
     /**

--- a/src/Query/GrammarWhere.php
+++ b/src/Query/GrammarWhere.php
@@ -46,14 +46,14 @@ trait GrammarWhere
     /**
      * Compile a "like" clause.
      *
-     * @param array{caseInsensitive: bool, column: string, value: mixed} $where
+     * @param array{caseSensitive: bool, column: string, value: mixed} $where
      */
     public function whereLike(Builder $query, $where): string
     {
-        return match ((bool) $where['caseInsensitive']) {
-            true => "{$this->wrap($where['column'])} ilike {$this->parameter($where['value'])}",
-            false => "{$this->wrap($where['column'])} like {$this->parameter($where['value'])}",
-        };
+        $where['operator'] = $where['not'] ? 'not ' : '';
+        $where['operator'] .= $where['caseSensitive'] ? 'like' : 'ilike';
+
+        return "{$this->wrap($where['column'])} {$where['operator']} {$this->parameter($where['value'])}";
     }
 
     /**

--- a/src/Schema/Grammars/GrammarTable.php
+++ b/src/Schema/Grammars/GrammarTable.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tpetry\PostgresqlEnhanced\Schema\Grammars;
 
-use Arr;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Fluent;
 
 trait GrammarTable

--- a/src/Schema/Grammars/GrammarTable.php
+++ b/src/Schema/Grammars/GrammarTable.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tpetry\PostgresqlEnhanced\Schema\Grammars;
 
+use Arr;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Fluent;
 
 trait GrammarTable

--- a/tests/Query/WhereTest.php
+++ b/tests/Query/WhereTest.php
@@ -99,7 +99,7 @@ class WhereTest extends TestCase
             $this->getConnection()->table('example')->orWhereLike('str', 'OamekKIC', true)->orWhereLike('str', 'HmC3xURl', true)->get();
         });
         $this->assertEquals(
-            ['select * from "example" where "str" like ? or "str" like ?', 'select * from "example" where "str" ilike ? or "str" ilike ?'],
+            ['select * from "example" where "str" ilike ? or "str" ilike ?', 'select * from "example" where "str" like ? or "str" like ?'],
             array_column($queries, 'query'),
         );
         $this->assertEquals(
@@ -258,7 +258,7 @@ class WhereTest extends TestCase
             $this->getConnection()->table('example')->whereLike('str', 'IcuC5Cqz', true)->get();
         });
         $this->assertEquals(
-            ['select * from "example" where "str" like ?', 'select * from "example" where "str" ilike ?'],
+            ['select * from "example" where "str" ilike ?', 'select * from "example" where "str" like ?'],
             array_column($queries, 'query'),
         );
         $this->assertEquals(


### PR DESCRIPTION
Fixes https://github.com/tpetry/laravel-postgresql-enhanced/issues/89

Since Laravel v11.17 (https://github.com/laravel/framework/pull/52147), `whereLike` and `orWhereLike` exist and are no longer compatible with this package's version of these methods.

This pull request adapts their definitions (and unfortunately, behavior) to work with the latest version of Laravel. The `caseInsensitive` parameter has been renamed to `caseSensitive` and its logic updated to be the same as Laravel.

This is a draft PR because I couldn't run tests on my computer, and documentation regarding the changes is missing.

THIS IS A BREAKING CHANGE.