### PR TITLE
Added methods to support custom data types.

### DIFF
--- a/src/Schema/BlueprintTypes.php
+++ b/src/Schema/BlueprintTypes.php
@@ -81,6 +81,14 @@ trait BlueprintTypes
     }
 
     /**
+     * Create a new type column on the table.
+     */
+    public function type(string $column, string $type): ColumnDefinition
+    {
+        return $this->domain($column, $type);
+    }
+
+    /**
      * Create a new european article number column on the table.
      */
     public function europeanArticleNumber13(string $column): ColumnDefinition

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -13,6 +13,7 @@ class Builder extends PostgresBuilder
     use BuilderDomain;
     use BuilderExtension;
     use BuilderFunction;
+    use BuilderType;
     use BuilderView;
 
     /**

--- a/src/Schema/BuilderType.php
+++ b/src/Schema/BuilderType.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tpetry\PostgresqlEnhanced\Schema;
+
+use Closure;
+use Tpetry\PostgresqlEnhanced\Support\Helpers\Query;
+
+trait BuilderType
+{
+    /**
+     * Change a type in the schema.
+     */
+    public function changeType(string $name, ?string $alteration = null): void
+    {
+        $sql = match (filled($alteration)) {
+            false => "alter type {$name}",
+            true => "alter type {$name} {$alteration}",
+        };
+
+        $this->getConnection()->statement($sql);
+    }
+
+    /**
+     * Create a new data type in the schema.
+     */
+    public function createType(string $name, string $type): void
+    {
+        $sql = match (filled($type)) {
+            false => "create type {$this->getConnection()->getSchemaGrammar()->wrap($name)}",
+            true => "create type {$this->getConnection()->getSchemaGrammar()->wrap($name)} as {$type}",
+        };
+
+        $this->getConnection()->statement($sql);
+    }
+
+    /**
+     * Drop types from the schema.
+     */
+    public function dropType(string ...$name): void
+    {
+        $names = $this->getConnection()->getSchemaGrammar()->namize($name);
+        $this->getConnection()->statement("drop type {$names}");
+    }
+
+    /**
+     * Drop types from the schema if they exist.
+     */
+    public function dropTypeIfExists(string ...$name): void
+    {
+        $names = $this->getConnection()->getSchemaGrammar()->namize($name);
+        $this->getConnection()->statement("drop type if exists {$names}");
+    }
+}

--- a/src/Schema/BuilderType.php
+++ b/src/Schema/BuilderType.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tpetry\PostgresqlEnhanced\Schema;
 
-use Closure;
 use Tpetry\PostgresqlEnhanced\Support\Helpers\Query;
 
 trait BuilderType

--- a/src/Schema/BuilderType.php
+++ b/src/Schema/BuilderType.php
@@ -27,7 +27,7 @@ trait BuilderType
     public function createType(string $name, string $type): void
     {
         $sql = match (filled($type)) {
-            false => "create type {$this->getConnection()->getSchemaGrammar()->wrap($name)}",
+            false => "create type {$name}",
             true => "create type {$this->getConnection()->getSchemaGrammar()->wrap($name)} as {$type}",
         };
 

--- a/src/Schema/BuilderType.php
+++ b/src/Schema/BuilderType.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Tpetry\PostgresqlEnhanced\Schema;
 
-use Tpetry\PostgresqlEnhanced\Support\Helpers\Query;
-
 trait BuilderType
 {
     /**
@@ -19,6 +17,30 @@ trait BuilderType
         };
 
         $this->getConnection()->statement($sql);
+    }
+
+    /**
+     * Rename a type in the schema.
+     */
+    public function changeTypeName(string $name, string $newName): void
+    {
+        $this->changeType($name, "rename to {$newName}");
+    }
+
+    /**
+     * Add a new value to enum type in the schema.
+     */
+    public function changeTypeToAddEnumValue(string $name, string $newValue): void
+    {
+        $this->changeType($name, "add value if not exists '{$newValue}'");
+    }
+
+    /**
+     * Rename a value in enum type in the schema.
+     */
+    public function changeEnumTypeValueName(string $name, string $existingValue, string $newValue): void
+    {
+        $this->changeType($name, "rename value '{$existingValue}' to '{$newValue}'");
     }
 
     /**

--- a/src/Support/Facades/Schema.php
+++ b/src/Support/Facades/Schema.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Schema as BaseSchema;
 
 /**
  * @method static void changeDomainConstraint(string $name, null|string|(callable(\Tpetry\PostgresqlEnhanced\Query\Builder): mixed) $check)
- * @method static void changeType( string $name, ?string $alteration = null )
+ * @method static void changeType(string $name, ?string $alteration = null)
  * @method static void createDomain(string $name, string $type, string|(callable(\Tpetry\PostgresqlEnhanced\Query\Builder): mixed) $check = null)
  * @method static void dropDomain(string ...$name)
  * @method static void dropDomainIfExists(string ...$name)
@@ -19,7 +19,7 @@ use Illuminate\Support\Facades\Schema as BaseSchema;
  * @method static void createFunctionOrReplace(string $name, array $parameters, array|string $return, string $language, string $body, array $options = [])
  * @method static void createRecursiveView(string $name, Builder|string $query, array $columns)
  * @method static void createRecursiveViewOrReplace(string $name, Builder|string $query, array $columns)
- * @method static void createType( string $name, string $type )
+ * @method static void createType(string $name, string $type)
  * @method static void createMaterializedView(string $name, Builder|string $query, bool $withData = true, array $columns = [])
  * @method static void createView(string $name, Builder|string $query, array $columns = [])
  * @method static void createViewOrReplace(string $name, Builder|string $query, array $columns = [])
@@ -27,8 +27,8 @@ use Illuminate\Support\Facades\Schema as BaseSchema;
  * @method static void dropExtensionIfExists(string ...$name)
  * @method static void dropFunction(string $name, ?array $arguments = null)
  * @method static void dropFunctionIfExists(string $name, ?array $arguments = null)
- * @method static void dropType( string ...$name )
- * @method static void dropTypeIfExists( string ...$name )
+ * @method static void dropType(string ...$name)
+ * @method static void dropTypeIfExists(string ...$name)
  * @method static void dropView(string ...$name)
  * @method static void dropViewIfExists(string ...$name)
  * @method static void dropMaterializedView(string ...$name)

--- a/src/Support/Facades/Schema.php
+++ b/src/Support/Facades/Schema.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Schema as BaseSchema;
 
 /**
  * @method static void changeDomainConstraint(string $name, null|string|(callable(\Tpetry\PostgresqlEnhanced\Query\Builder): mixed) $check)
+ * @method static void changeType( string $name, ?string $alteration = null )
  * @method static void createDomain(string $name, string $type, string|(callable(\Tpetry\PostgresqlEnhanced\Query\Builder): mixed) $check = null)
  * @method static void dropDomain(string ...$name)
  * @method static void dropDomainIfExists(string ...$name)
@@ -18,6 +19,7 @@ use Illuminate\Support\Facades\Schema as BaseSchema;
  * @method static void createFunctionOrReplace(string $name, array $parameters, array|string $return, string $language, string $body, array $options = [])
  * @method static void createRecursiveView(string $name, Builder|string $query, array $columns)
  * @method static void createRecursiveViewOrReplace(string $name, Builder|string $query, array $columns)
+ * @method static void createType( string $name, string $type )
  * @method static void createMaterializedView(string $name, Builder|string $query, bool $withData = true, array $columns = [])
  * @method static void createView(string $name, Builder|string $query, array $columns = [])
  * @method static void createViewOrReplace(string $name, Builder|string $query, array $columns = [])
@@ -25,6 +27,8 @@ use Illuminate\Support\Facades\Schema as BaseSchema;
  * @method static void dropExtensionIfExists(string ...$name)
  * @method static void dropFunction(string $name, ?array $arguments = null)
  * @method static void dropFunctionIfExists(string $name, ?array $arguments = null)
+ * @method static void dropType( string ...$name )
+ * @method static void dropTypeIfExists( string ...$name )
  * @method static void dropView(string ...$name)
  * @method static void dropViewIfExists(string ...$name)
  * @method static void dropMaterializedView(string ...$name)

--- a/src/Support/Facades/Schema.php
+++ b/src/Support/Facades/Schema.php
@@ -9,7 +9,10 @@ use Illuminate\Support\Facades\Schema as BaseSchema;
 
 /**
  * @method static void changeDomainConstraint(string $name, null|string|(callable(\Tpetry\PostgresqlEnhanced\Query\Builder): mixed) $check)
+ * @method static void changeEnumTypeValueName( string $name, string $existingValue, string $newValue )
  * @method static void changeType(string $name, ?string $alteration = null)
+ * @method static void changeTypeName( string $name, string $newName )
+ * @method static void changeTypeToAddEnumValue(string $name, string $newValue)
  * @method static void createDomain(string $name, string $type, string|(callable(\Tpetry\PostgresqlEnhanced\Query\Builder): mixed) $check = null)
  * @method static void dropDomain(string ...$name)
  * @method static void dropDomainIfExists(string ...$name)

--- a/tests/Migration/CustomDataTypesTest.php
+++ b/tests/Migration/CustomDataTypesTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tpetry\PostgresqlEnhanced\Tests\Migration;
+
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+use Tpetry\PostgresqlEnhanced\Tests\TestCase;
+
+class CustomDataTypesTest extends TestCase
+{
+    public function testChangeTypeWithAlteration(): void
+    {
+        $this->getConnection()->statement("create type chocolate_type as enum('dark', 'white')");
+        $queries = $this->withQueryLog(function (): void {
+            Schema::changeType('chocolate_type', 'rename to choco_type');
+        });
+        $this->assertEquals([
+            'alter type chocolate_type rename to choco_type',
+        ], array_column($queries, 'query'));
+    }
+
+    public function testChangeTypeWithoutAlteration(): void
+    {
+        $this->getConnection()->statement("create type chocolate_type as enum('dark', 'white')");
+        $queries = $this->withQueryLog(function (): void {
+            Schema::changeType('chocolate_type rename to choco_type');
+        });
+        $this->assertEquals([
+            'alter type chocolate_type rename to choco_type',
+        ], array_column($queries, 'query'));
+    }
+
+    public function testChangeTypeName(): void
+    {
+        $this->getConnection()->statement("create type chocolate_type as enum('dark', 'white')");
+        $queries = $this->withQueryLog(function (): void {
+            Schema::changeTypeName('chocolate_type', 'choco_type');
+        });
+        $this->assertEquals([
+            'alter type chocolate_type rename to choco_type',
+        ], array_column($queries, 'query'));
+    }
+
+    public function testChangeTypeToAddEnumValue(): void
+    {
+        $this->getConnection()->statement("create type chocolate_type as enum('dark', 'white')");
+        $queries = $this->withQueryLog(function (): void {
+            Schema::changeTypeToAddEnumValue('chocolate_type', 'medium');
+        });
+        $this->assertEquals([
+            "alter type chocolate_type add value if not exists 'medium'",
+        ], array_column($queries, 'query'));
+    }
+
+    public function testChangeEnumTypeValueName(): void
+    {
+        $this->getConnection()->statement("create type chocolate_type as enum('dark', 'white')");
+        $queries = $this->withQueryLog(function (): void {
+            Schema::changeEnumTypeValueName('chocolate_type', 'white', 'milk');
+        });
+        $this->assertEquals([
+            "alter type chocolate_type rename value 'white' to 'milk'",
+        ], array_column($queries, 'query'));
+    }
+
+    public function testCreateType(): void
+    {
+        $queries = $this->withQueryLog(function (): void {
+            Schema::createType('chocolate_type', "enum('dark', 'white')");
+        });
+        $this->assertEquals([
+            "create type chocolate_type as enum('dark', 'white')",
+        ], array_column($queries, 'query'));
+    }
+
+    public function testCreateTypeWithoutSeparateTypeDefinition(): void
+    {
+        $queries = $this->withQueryLog(function (): void {
+            Schema::createType("chocolate_type as enum('dark', 'white')", '');
+        });
+        $this->assertEquals([
+            "create type chocolate_type as enum('dark', 'white')",
+        ], array_column($queries, 'query'));
+    }
+
+    public function testDropType(): void
+    {
+        $this->getConnection()->statement("create type chocolate_type as enum('dark', 'white')");
+        $this->getConnection()->statement("create type chocolate_origin as enum('swiss', 'belgian')");
+        $queries = $this->withQueryLog(function (): void {
+            Schema::dropType('chocolate_type', 'chocolate_origin');
+        });
+        $this->assertEquals(['drop type "chocolate_type", "chocolate_origin"'], array_column($queries, 'query'));
+    }
+
+    public function testDropTypeIfExists(): void
+    {
+        $this->getConnection()->statement("create type chocolate_type as enum('dark', 'white')");
+        $this->getConnection()->statement("create type chocolate_origin as enum('swiss', 'belgian')");
+        $queries = $this->withQueryLog(function (): void {
+            Schema::dropTypeIfExists('chocolate_type', 'chocolate_origin');
+        });
+        $this->assertEquals(['drop type if exists "chocolate_type", "chocolate_origin"'], array_column($queries, 'query'));
+    }
+
+    public function testUseType(): void
+    {
+        $this->getConnection()->statement("create type chocolate_type as enum('dark', 'white')");
+        $queries = $this->withQueryLog(function (): void {
+            Schema::create('chocolates', function (Blueprint $table): void {
+                $table->integer('id');
+                $table->type('chocolate_type', 'chocolate_type');
+                $table->timestampTz('date');
+            });
+        });
+        $this->assertEquals(['create table "chocolates" ("id" integer not null, "chocolate_type" chocolate_type not null, "date" timestamp(0) with time zone not null)'], array_column($queries, 'query'));
+    }
+}


### PR DESCRIPTION
This is a followup to #91.

This PR adds support for custom data types - `create`, `alter`, and `drop`.

`Schema` facade gets these additions:

```php
Schema::changeType(string $name, ?string $alteration = null): void
Schema::changeTypeName(string $name, string $newName): void
Schema::changeTypeToAddEnumValue(string $name, string $newValue): void
Schema::changeEnumTypeValueName(string $name, string $existingValue, string $newValue): void
Schema::createType(string $name, string $type): void
Schema::dropType(string ...$name): void
Schema::dropTypeIfExists(string ...$name): void
```

`Blueprint` class gets this addition

```php
public function type(string $column, string $type): ColumnDefinition
```

The `type()` method above is just syntactic sugar, a wrapper around the `domain()` method, to allow for expressive code when assigning a custom data type to a column.
