### PR TITLE
fix: whereNotLike misses the not in the sql query

### DIFF
--- a/src/Query/BuilderWhere.php
+++ b/src/Query/BuilderWhere.php
@@ -111,6 +111,18 @@ trait BuilderWhere
     }
 
     /**
+     * Add an "or where not like" clause to the query.
+     *
+     * @param Expression|string $column
+     * @param Expression|string $value
+     * @param bool $caseSensitive
+     */
+    public function orWhereNotLike($column, $value, $caseSensitive = false): static
+    {
+        return $this->whereNotLike($column, $value, $caseSensitive, 'or');
+    }
+
+    /**
      * Add a where all statement to the query.
      *
      * @param Expression|string $column
@@ -178,7 +190,7 @@ trait BuilderWhere
     }
 
     /**
-     * Add a "where month" statement to the query.
+     * Add a "where like" statement to the query.
      *
      * @param Expression|string $column
      * @param Expression|string $value
@@ -234,5 +246,18 @@ trait BuilderWhere
     public function whereNotBoolean($column, bool $value): static
     {
         return $this->where($column, '!=', new Expression(var_export($value, true)));
+    }
+
+    /**
+     * Add a "where not like" statement to the query.
+     *
+     * @param Expression|string $column
+     * @param Expression|string $value
+     * @param bool $caseSensitive
+     * @param string $boolean
+     */
+    public function whereNotLike($column, $value, $caseSensitive = false, $boolean = 'and'): static
+    {
+        return $this->whereLike($column, $value, $caseSensitive, $boolean, true);
     }
 }

--- a/src/Query/BuilderWhere.php
+++ b/src/Query/BuilderWhere.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tpetry\PostgresqlEnhanced\Query;
 
 use Illuminate\Database\Query\Expression;
-use Illuminate\Support\Facades\App;
 
 trait BuilderWhere
 {
@@ -68,10 +67,6 @@ trait BuilderWhere
      */
     public function orWhereLike($column, $value, $caseSensitive = false): static
     {
-        if (version_compare(App::version(), '11.17.0', '>=')) {
-            return parent::orWhereLike($column, $value, $caseSensitive);
-        }
-
         return $this->whereLike($column, $value, $caseSensitive, 'or', false);
     }
 
@@ -193,10 +188,6 @@ trait BuilderWhere
      */
     public function whereLike($column, $value, $caseSensitive = false, $boolean = 'and', $not = false): static
     {
-        if (version_compare(App::version(), '11.17.0', '>=')) {
-            return parent::whereLike($column, $value, $caseSensitive, $boolean, $not);
-        }
-
         $type = 'like';
 
         $this->wheres[] = compact('type', 'column', 'value', 'caseSensitive', 'boolean', 'not');

--- a/src/Query/BuilderWhere.php
+++ b/src/Query/BuilderWhere.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tpetry\PostgresqlEnhanced\Query;
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Support\Facades\App;
 
 trait BuilderWhere
 {
@@ -67,6 +68,10 @@ trait BuilderWhere
      */
     public function orWhereLike($column, $value, $caseSensitive = false): static
     {
+        if (version_compare(App::version(), '11.17.0', '>=')) {
+            return parent::orWhereLike($column, $value, $caseSensitive);
+        }
+
         return $this->whereLike($column, $value, $caseSensitive, 'or', false);
     }
 
@@ -188,6 +193,10 @@ trait BuilderWhere
      */
     public function whereLike($column, $value, $caseSensitive = false, $boolean = 'and', $not = false): static
     {
+        if (version_compare(App::version(), '11.17.0', '>=')) {
+            return parent::whereLike($column, $value, $caseSensitive, $boolean, $not);
+        }
+
         $type = 'like';
 
         $this->wheres[] = compact('type', 'column', 'value', 'caseSensitive', 'boolean', 'not');

--- a/src/Query/GrammarWhere.php
+++ b/src/Query/GrammarWhere.php
@@ -6,6 +6,7 @@ namespace Tpetry\PostgresqlEnhanced\Query;
 
 use Exception;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\App;
 
 trait GrammarWhere
 {
@@ -50,9 +51,13 @@ trait GrammarWhere
      */
     public function whereLike(Builder $query, $where): string
     {
+        if (version_compare(App::version(), '11.17.0', '>=')) {
+            return parent::whereLike($query, $where);
+        }
+
         $operator = $where['not'] ? 'not ' : '';
         $operator .= $where['caseSensitive'] ? 'like' : 'ilike';
-        
+
         return "{$this->wrap($where['column'])} {$operator} {$this->parameter($where['value'])}";
     }
 

--- a/src/Query/GrammarWhere.php
+++ b/src/Query/GrammarWhere.php
@@ -53,12 +53,7 @@ trait GrammarWhere
         $operator = $where['not'] ? 'not ' : '';
         $operator .= $where['caseSensitive'] ? 'like' : 'ilike';
 
-        return sprintf(
-            '%s::text %s %s',
-            $this->wrap($where['column']),
-            $operator,
-            $this->parameter($where['value']),
-        );
+        return "{$this->wrap($where['column'])}::text {$operator} {$this->parameter($where['value'])}";
     }
 
     /**

--- a/src/Query/GrammarWhere.php
+++ b/src/Query/GrammarWhere.php
@@ -6,7 +6,6 @@ namespace Tpetry\PostgresqlEnhanced\Query;
 
 use Exception;
 use Illuminate\Database\Query\Builder;
-use Illuminate\Support\Facades\App;
 
 trait GrammarWhere
 {
@@ -51,10 +50,6 @@ trait GrammarWhere
      */
     public function whereLike(Builder $query, $where): string
     {
-        if (version_compare(App::version(), '11.17.0', '>=')) {
-            return parent::whereLike($query, $where);
-        }
-
         $operator = $where['not'] ? 'not ' : '';
         $operator .= $where['caseSensitive'] ? 'like' : 'ilike';
 

--- a/src/Query/GrammarWhere.php
+++ b/src/Query/GrammarWhere.php
@@ -50,10 +50,10 @@ trait GrammarWhere
      */
     public function whereLike(Builder $query, $where): string
     {
-        return match ($where['caseSensitive']) {
-            true => "{$this->wrap($where['column'])} like {$this->parameter($where['value'])}",
-            false => "{$this->wrap($where['column'])} ilike {$this->parameter($where['value'])}",
-        };
+        $operator = $where['not'] ? 'not ' : '';
+        $operator .= $where['caseSensitive'] ? 'like' : 'ilike';
+        
+        return "{$this->wrap($where['column'])} {$operator} {$this->parameter($where['value'])}";
     }
 
     /**

--- a/src/Query/GrammarWhere.php
+++ b/src/Query/GrammarWhere.php
@@ -58,7 +58,12 @@ trait GrammarWhere
         $operator = $where['not'] ? 'not ' : '';
         $operator .= $where['caseSensitive'] ? 'like' : 'ilike';
 
-        return "{$this->wrap($where['column'])} {$operator} {$this->parameter($where['value'])}";
+        return sprintf(
+            '%s::text %s %s',
+            $this->wrap($where['column']),
+            $operator,
+            $this->parameter($where['value']),
+        );
     }
 
     /**

--- a/src/Query/GrammarWhere.php
+++ b/src/Query/GrammarWhere.php
@@ -46,7 +46,7 @@ trait GrammarWhere
     /**
      * Compile a "like" clause.
      *
-     * @param array{caseSensitive: bool, column: string, value: mixed} $where
+     * @param array{caseSensitive: bool, column: string, not: bool, value: mixed} $where
      */
     public function whereLike(Builder $query, $where): string
     {

--- a/tests/Query/WhereTest.php
+++ b/tests/Query/WhereTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tpetry\PostgresqlEnhanced\Tests\Query;
 
-use Illuminate\Support\Facades\App;
 use Tpetry\PostgresqlEnhanced\Tests\TestCase;
 
 class WhereTest extends TestCase
@@ -99,19 +98,10 @@ class WhereTest extends TestCase
             $this->getConnection()->table('example')->orWhereLike('str', 'ZsbBUJmR')->orWhereLike('str', '7Cc1Uf8t')->get();
             $this->getConnection()->table('example')->orWhereLike('str', 'OamekKIC', true)->orWhereLike('str', 'HmC3xURl', true)->get();
         });
-
-        if (version_compare(App::version(), '11.17.0', '>=')) {
-            $this->assertEquals(
-                ['select * from "example" where "str"::text ilike ? or "str"::text ilike ?', 'select * from "example" where "str"::text like ? or "str"::text like ?'],
-                array_column($queries, 'query'),
-            );
-        } else {
-            $this->assertEquals(
-                ['select * from "example" where "str" ilike ? or "str" ilike ?', 'select * from "example" where "str" like ? or "str" like ?'],
-                array_column($queries, 'query'),
-            );
-        }
-
+        $this->assertEquals(
+            ['select * from "example" where "str"::text ilike ? or "str"::text ilike ?', 'select * from "example" where "str"::text like ? or "str"::text like ?'],
+            array_column($queries, 'query'),
+        );
         $this->assertEquals(
             [['ZsbBUJmR', '7Cc1Uf8t'], ['OamekKIC', 'HmC3xURl']],
             array_column($queries, 'bindings'),
@@ -190,19 +180,10 @@ class WhereTest extends TestCase
             $this->getConnection()->table('example')->orWhereNotLike('str', 'ZsbBUJmR')->orWhereNotLike('str', '7Cc1Uf8t')->get();
             $this->getConnection()->table('example')->orWhereNotLike('str', 'OamekKIC', true)->orWhereNotLike('str', 'HmC3xURl', true)->get();
         });
-
-        if (version_compare(App::version(), '11.17.0', '>=')) {
-            $this->assertEquals(
-                ['select * from "example" where "str"::text not ilike ? or "str"::text not ilike ?', 'select * from "example" where "str"::text not like ? or "str"::text not like ?'],
-                array_column($queries, 'query'),
-            );
-        } else {
-            $this->assertEquals(
-                ['select * from "example" where "str" not ilike ? or "str" not ilike ?', 'select * from "example" where "str" not like ? or "str" not like ?'],
-                array_column($queries, 'query'),
-            );
-        }
-
+        $this->assertEquals(
+            ['select * from "example" where "str"::text not ilike ? or "str"::text not ilike ?', 'select * from "example" where "str"::text not like ? or "str"::text not like ?'],
+            array_column($queries, 'query'),
+        );
         $this->assertEquals(
             [['ZsbBUJmR', '7Cc1Uf8t'], ['OamekKIC', 'HmC3xURl']],
             array_column($queries, 'bindings'),
@@ -294,19 +275,10 @@ class WhereTest extends TestCase
             $this->getConnection()->table('example')->whereLike('str', 'UkAymQlg')->get();
             $this->getConnection()->table('example')->whereLike('str', 'IcuC5Cqz', true)->get();
         });
-
-        if (version_compare(App::version(), '11.17.0', '>=')) {
-            $this->assertEquals(
-                ['select * from "example" where "str"::text ilike ?', 'select * from "example" where "str"::text like ?'],
-                array_column($queries, 'query'),
-            );
-        } else {
-            $this->assertEquals(
-                ['select * from "example" where "str" ilike ?', 'select * from "example" where "str" like ?'],
-                array_column($queries, 'query'),
-            );
-        }
-
+        $this->assertEquals(
+            ['select * from "example" where "str"::text ilike ?', 'select * from "example" where "str"::text like ?'],
+            array_column($queries, 'query'),
+        );
         $this->assertEquals(
             [['UkAymQlg'], ['IcuC5Cqz']],
             array_column($queries, 'bindings'),
@@ -385,19 +357,10 @@ class WhereTest extends TestCase
             $this->getConnection()->table('example')->whereNotLike('str', 'UkAymQlg')->get();
             $this->getConnection()->table('example')->whereNotLike('str', 'IcuC5Cqz', true)->get();
         });
-
-        if (version_compare(App::version(), '11.17.0', '>=')) {
-            $this->assertEquals(
-                ['select * from "example" where "str"::text not ilike ?', 'select * from "example" where "str"::text not like ?'],
-                array_column($queries, 'query'),
-            );
-        } else {
-            $this->assertEquals(
-                ['select * from "example" where "str" not ilike ?', 'select * from "example" where "str" not like ?'],
-                array_column($queries, 'query'),
-            );
-        }
-
+        $this->assertEquals(
+            ['select * from "example" where "str"::text not ilike ?', 'select * from "example" where "str"::text not like ?'],
+            array_column($queries, 'query'),
+        );
         $this->assertEquals(
             [['UkAymQlg'], ['IcuC5Cqz']],
             array_column($queries, 'bindings'),

--- a/tests/Query/WhereTest.php
+++ b/tests/Query/WhereTest.php
@@ -177,15 +177,15 @@ class WhereTest extends TestCase
         $this->getConnection()->unprepared('CREATE TABLE example (str text)');
 
         $queries = $this->withQueryLog(function (): void {
-            $this->getConnection()->table('example')->orWhereNotLike('str', 'ZsbBUJmR')->orWhereNotLike('str', '7Cc1Uf8t')->get();
-            $this->getConnection()->table('example')->orWhereNotLike('str', 'OamekKIC', true)->orWhereNotLike('str', 'HmC3xURl', true)->get();
+            $this->getConnection()->table('example')->orWhereNotLike('str', 'AERLFW4s')->orWhereNotLike('str', 'sPtXxruW')->get();
+            $this->getConnection()->table('example')->orWhereNotLike('str', 'EWnGRRc5', true)->orWhereNotLike('str', 'wihuWcph', true)->get();
         });
         $this->assertEquals(
             ['select * from "example" where "str"::text not ilike ? or "str"::text not ilike ?', 'select * from "example" where "str"::text not like ? or "str"::text not like ?'],
             array_column($queries, 'query'),
         );
         $this->assertEquals(
-            [['ZsbBUJmR', '7Cc1Uf8t'], ['OamekKIC', 'HmC3xURl']],
+            [['AERLFW4s', 'sPtXxruW'], ['EWnGRRc5', 'wihuWcph']],
             array_column($queries, 'bindings'),
         );
     }
@@ -354,15 +354,15 @@ class WhereTest extends TestCase
         $this->getConnection()->unprepared('CREATE TABLE example (str text)');
 
         $queries = $this->withQueryLog(function (): void {
-            $this->getConnection()->table('example')->whereNotLike('str', 'UkAymQlg')->get();
-            $this->getConnection()->table('example')->whereNotLike('str', 'IcuC5Cqz', true)->get();
+            $this->getConnection()->table('example')->whereNotLike('str', 'mgb7DtKz')->get();
+            $this->getConnection()->table('example')->whereNotLike('str', 'tpx6Bxpm', true)->get();
         });
         $this->assertEquals(
             ['select * from "example" where "str"::text not ilike ?', 'select * from "example" where "str"::text not like ?'],
             array_column($queries, 'query'),
         );
         $this->assertEquals(
-            [['UkAymQlg'], ['IcuC5Cqz']],
+            [['mgb7DtKz'], ['tpx6Bxpm']],
             array_column($queries, 'bindings'),
         );
     }

--- a/tests/Query/WhereTest.php
+++ b/tests/Query/WhereTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tpetry\PostgresqlEnhanced\Tests\Query;
 
+use Illuminate\Support\Facades\App;
 use Tpetry\PostgresqlEnhanced\Tests\TestCase;
 
 class WhereTest extends TestCase
@@ -98,28 +99,19 @@ class WhereTest extends TestCase
             $this->getConnection()->table('example')->orWhereLike('str', 'ZsbBUJmR')->orWhereLike('str', '7Cc1Uf8t')->get();
             $this->getConnection()->table('example')->orWhereLike('str', 'OamekKIC', true)->orWhereLike('str', 'HmC3xURl', true)->get();
         });
-        $this->assertEquals(
-            ['select * from "example" where "str" ilike ? or "str" ilike ?', 'select * from "example" where "str" like ? or "str" like ?'],
-            array_column($queries, 'query'),
-        );
-        $this->assertEquals(
-            [['ZsbBUJmR', '7Cc1Uf8t'], ['OamekKIC', 'HmC3xURl']],
-            array_column($queries, 'bindings'),
-        );
-    }
 
-    public function testOrWhereNotLike(): void
-    {
-        $this->getConnection()->unprepared('CREATE TABLE example (str text)');
+        if (version_compare(App::version(), '11.17.0', '>=')) {
+            $this->assertEquals(
+                ['select * from "example" where "str"::text ilike ? or "str"::text ilike ?', 'select * from "example" where "str"::text like ? or "str"::text like ?'],
+                array_column($queries, 'query'),
+            );
+        } else {
+            $this->assertEquals(
+                ['select * from "example" where "str" ilike ? or "str" ilike ?', 'select * from "example" where "str" like ? or "str" like ?'],
+                array_column($queries, 'query'),
+            );
+        }
 
-        $queries = $this->withQueryLog(function (): void {
-            $this->getConnection()->table('example')->orWhereNotLike('str', 'ZsbBUJmR')->orWhereNotLike('str', '7Cc1Uf8t')->get();
-            $this->getConnection()->table('example')->orWhereNotLike('str', 'OamekKIC', true)->orWhereNotLike('str', 'HmC3xURl', true)->get();
-        });
-        $this->assertEquals(
-            ['select * from "example" where "str" not ilike ? or "str" not ilike ?', 'select * from "example" where "str" not like ? or "str" not like ?'],
-            array_column($queries, 'query'),
-        );
         $this->assertEquals(
             [['ZsbBUJmR', '7Cc1Uf8t'], ['OamekKIC', 'HmC3xURl']],
             array_column($queries, 'bindings'),
@@ -187,6 +179,33 @@ class WhereTest extends TestCase
         $this->assertEquals(
             ['select * from "example" where "val" != true or "val" != false'],
             array_column($queries, 'query'),
+        );
+    }
+
+    public function testOrWhereNotLike(): void
+    {
+        $this->getConnection()->unprepared('CREATE TABLE example (str text)');
+
+        $queries = $this->withQueryLog(function (): void {
+            $this->getConnection()->table('example')->orWhereNotLike('str', 'ZsbBUJmR')->orWhereNotLike('str', '7Cc1Uf8t')->get();
+            $this->getConnection()->table('example')->orWhereNotLike('str', 'OamekKIC', true)->orWhereNotLike('str', 'HmC3xURl', true)->get();
+        });
+
+        if (version_compare(App::version(), '11.17.0', '>=')) {
+            $this->assertEquals(
+                ['select * from "example" where "str"::text not ilike ? or "str"::text not ilike ?', 'select * from "example" where "str"::text not like ? or "str"::text not like ?'],
+                array_column($queries, 'query'),
+            );
+        } else {
+            $this->assertEquals(
+                ['select * from "example" where "str" not ilike ? or "str" not ilike ?', 'select * from "example" where "str" not like ? or "str" not like ?'],
+                array_column($queries, 'query'),
+            );
+        }
+
+        $this->assertEquals(
+            [['ZsbBUJmR', '7Cc1Uf8t'], ['OamekKIC', 'HmC3xURl']],
+            array_column($queries, 'bindings'),
         );
     }
 
@@ -275,28 +294,19 @@ class WhereTest extends TestCase
             $this->getConnection()->table('example')->whereLike('str', 'UkAymQlg')->get();
             $this->getConnection()->table('example')->whereLike('str', 'IcuC5Cqz', true)->get();
         });
-        $this->assertEquals(
-            ['select * from "example" where "str" ilike ?', 'select * from "example" where "str" like ?'],
-            array_column($queries, 'query'),
-        );
-        $this->assertEquals(
-            [['UkAymQlg'], ['IcuC5Cqz']],
-            array_column($queries, 'bindings'),
-        );
-    }
 
-    public function testWhereNotLike(): void
-    {
-        $this->getConnection()->unprepared('CREATE TABLE example (str text)');
+        if (version_compare(App::version(), '11.17.0', '>=')) {
+            $this->assertEquals(
+                ['select * from "example" where "str"::text ilike ?', 'select * from "example" where "str"::text like ?'],
+                array_column($queries, 'query'),
+            );
+        } else {
+            $this->assertEquals(
+                ['select * from "example" where "str" ilike ?', 'select * from "example" where "str" like ?'],
+                array_column($queries, 'query'),
+            );
+        }
 
-        $queries = $this->withQueryLog(function (): void {
-            $this->getConnection()->table('example')->whereNotLike('str', 'UkAymQlg')->get();
-            $this->getConnection()->table('example')->whereNotLike('str', 'IcuC5Cqz', true)->get();
-        });
-        $this->assertEquals(
-            ['select * from "example" where "str" not ilike ?', 'select * from "example" where "str" not like ?'],
-            array_column($queries, 'query'),
-        );
         $this->assertEquals(
             [['UkAymQlg'], ['IcuC5Cqz']],
             array_column($queries, 'bindings'),
@@ -364,6 +374,33 @@ class WhereTest extends TestCase
         $this->assertEquals(
             ['select * from "example" where "val" != true and "val" != false'],
             array_column($queries, 'query'),
+        );
+    }
+
+    public function testWhereNotLike(): void
+    {
+        $this->getConnection()->unprepared('CREATE TABLE example (str text)');
+
+        $queries = $this->withQueryLog(function (): void {
+            $this->getConnection()->table('example')->whereNotLike('str', 'UkAymQlg')->get();
+            $this->getConnection()->table('example')->whereNotLike('str', 'IcuC5Cqz', true)->get();
+        });
+
+        if (version_compare(App::version(), '11.17.0', '>=')) {
+            $this->assertEquals(
+                ['select * from "example" where "str"::text not ilike ?', 'select * from "example" where "str"::text not like ?'],
+                array_column($queries, 'query'),
+            );
+        } else {
+            $this->assertEquals(
+                ['select * from "example" where "str" not ilike ?', 'select * from "example" where "str" not like ?'],
+                array_column($queries, 'query'),
+            );
+        }
+
+        $this->assertEquals(
+            [['UkAymQlg'], ['IcuC5Cqz']],
+            array_column($queries, 'bindings'),
         );
     }
 }

--- a/tests/Query/WhereTest.php
+++ b/tests/Query/WhereTest.php
@@ -108,6 +108,24 @@ class WhereTest extends TestCase
         );
     }
 
+    public function testOrWhereNotLike(): void
+    {
+        $this->getConnection()->unprepared('CREATE TABLE example (str text)');
+
+        $queries = $this->withQueryLog(function (): void {
+            $this->getConnection()->table('example')->orWhereNotLike('str', 'ZsbBUJmR')->orWhereNotLike('str', '7Cc1Uf8t')->get();
+            $this->getConnection()->table('example')->orWhereNotLike('str', 'OamekKIC', true)->orWhereNotLike('str', 'HmC3xURl', true)->get();
+        });
+        $this->assertEquals(
+            ['select * from "example" where "str" not ilike ? or "str" not ilike ?', 'select * from "example" where "str" not like ? or "str" not like ?'],
+            array_column($queries, 'query'),
+        );
+        $this->assertEquals(
+            [['ZsbBUJmR', '7Cc1Uf8t'], ['OamekKIC', 'HmC3xURl']],
+            array_column($queries, 'bindings'),
+        );
+    }
+
     public function testOrWhereNotAllValues(): void
     {
         $this->getConnection()->unprepared('CREATE TABLE example (val text)');
@@ -259,6 +277,24 @@ class WhereTest extends TestCase
         });
         $this->assertEquals(
             ['select * from "example" where "str" ilike ?', 'select * from "example" where "str" like ?'],
+            array_column($queries, 'query'),
+        );
+        $this->assertEquals(
+            [['UkAymQlg'], ['IcuC5Cqz']],
+            array_column($queries, 'bindings'),
+        );
+    }
+
+    public function testWhereNotLike(): void
+    {
+        $this->getConnection()->unprepared('CREATE TABLE example (str text)');
+
+        $queries = $this->withQueryLog(function (): void {
+            $this->getConnection()->table('example')->whereNotLike('str', 'UkAymQlg')->get();
+            $this->getConnection()->table('example')->whereNotLike('str', 'IcuC5Cqz', true)->get();
+        });
+        $this->assertEquals(
+            ['select * from "example" where "str" not ilike ?', 'select * from "example" where "str" not like ?'],
             array_column($queries, 'query'),
         );
         $this->assertEquals(


### PR DESCRIPTION
At the moment when calling `whereNotLike` or `orWhereNotLike` the query is missing the 'not' in the query. This is actually super critical.

Is there a plan to implement something to only apply the `where*Like` queries of this package if you use laravel/framework < 11.19.0 ? in order to use the "real" implementation of laravel itself