### PR TITLE
fea(timescale): add support for `migrate_data`

### DIFF
--- a/src/Schema/Timescale/Actions/CreateHypertable.php
+++ b/src/Schema/Timescale/Actions/CreateHypertable.php
@@ -13,7 +13,8 @@ class CreateHypertable implements Action
         private string|int $interval,
         private ?string $partitionFunction = null,
         private bool $migrateData = false,
-    ) {}
+    ) {
+    }
 
     public function getValue(Grammar $grammar, string $table): array
     {
@@ -24,7 +25,7 @@ class CreateHypertable implements Action
     {
         $column = $grammar->escape($this->column);
         $interval = is_numeric($this->interval) ? $this->interval : "interval {$grammar->escape($this->interval)}";
-        $partitionFunction = transform($this->partitionFunction, fn(string $name) => $grammar->escape($name));
+        $partitionFunction = transform($this->partitionFunction, fn (string $name) => $grammar->escape($name));
 
         return match (filled($partitionFunction)) {
             false => "by_range({$column}, {$interval})",


### PR DESCRIPTION
This PR introduces support for migrating existing data when converting a regular table into a Timescale hypertable.

The default behavior is set to `false`.