### PR TITLE
Set `wasRecentlyCreated = true` for returning inserts

### DIFF
--- a/src/Eloquent/Mixins/BuilderReturning.php
+++ b/src/Eloquent/Mixins/BuilderReturning.php
@@ -56,7 +56,7 @@ class BuilderReturning
             /* @var \Illuminate\Database\Eloquent\Builder $this */
             return $this->hydrate(
                 $this->applyScopes()->getQuery()->insertReturning($values, $returning)->all()
-            );
+            )->each(fn (Model $model) => $model->wasRecentlyCreated = true);
         };
     }
 
@@ -66,7 +66,7 @@ class BuilderReturning
             /* @var \Illuminate\Database\Eloquent\Builder $this */
             return $this->hydrate(
                 $this->applyScopes()->getQuery()->insertUsingReturning($columns, $query, $returning)->all()
-            );
+            )->each(fn (Model $model) => $model->wasRecentlyCreated = true);
         };
     }
 

--- a/tests/Eloquent/BuilderReturningTest.php
+++ b/tests/Eloquent/BuilderReturningTest.php
@@ -234,6 +234,7 @@ class BuilderReturningTest extends TestCase
             $this->assertInstanceOf(Collection::class, $result);
             $this->assertEquals([['id' => 1, 'str' => 'L55uRXMI', 'created_at' => null, 'updated_at' => null, 'deleted_at' => null]], $result->toArray());
             $this->assertInstanceOf(ExampleTimestamps::class, $result->first());
+            $this->assertTrue($result->first()->wasRecentlyCreated);
         });
         $this->assertEquals(['insert into "example" ("str") values (?) returning *'], array_column($queries, 'query'));
     }
@@ -261,6 +262,7 @@ class BuilderReturningTest extends TestCase
             $this->assertInstanceOf(Collection::class, $result);
             $this->assertEquals([['str' => 'HarJvEmz']], $result->toArray());
             $this->assertInstanceOf(ExampleTimestamps::class, $result->first());
+            $this->assertTrue($result->first()->wasRecentlyCreated);
         });
         $this->assertEquals(['insert into "example" ("str") values (?) returning "str"'], array_column($queries, 'query'));
     }
@@ -275,6 +277,7 @@ class BuilderReturningTest extends TestCase
             $this->assertInstanceOf(Collection::class, $result);
             $this->assertEquals([['id' => 1, 'str' => 'LOfbaRG4', 'created_at' => null, 'updated_at' => null, 'deleted_at' => null]], $result->toArray());
             $this->assertInstanceOf(ExampleTimestamps::class, $result->first());
+            $this->assertTrue($result->first()->wasRecentlyCreated);
         });
         $this->assertEquals(['insert into "example" ("str") select \'LOfbaRG4\' returning *'], array_column($queries, 'query'));
     }
@@ -302,6 +305,7 @@ class BuilderReturningTest extends TestCase
             $this->assertInstanceOf(Collection::class, $result);
             $this->assertEquals([['str' => 'CT4TfugQ']], $result->toArray());
             $this->assertInstanceOf(ExampleTimestamps::class, $result->first());
+            $this->assertTrue($result->first()->wasRecentlyCreated);
         });
         $this->assertEquals(['insert into "example" ("str") select \'CT4TfugQ\' returning "str"'], array_column($queries, 'query'));
     }


### PR DESCRIPTION
When models are created using `insertReturning()` or `insertUsingReturning()`, the `$wasRecentlyCreated` property was incorrectly set to `false`. This PR fixes that behavior by setting it to `true`, identical to how Eloquent normally handles creates.