### PR TITLE
Make use of wrapTable to make it consistent with the `as` function

### DIFF
--- a/src/Schema/Timescale/CaggBlueprint.php
+++ b/src/Schema/Timescale/CaggBlueprint.php
@@ -93,7 +93,7 @@ class CaggBlueprint
      */
     public function realtime(bool $enabled = true): void
     {
-        $this->commands[] = fn (Connection $connection, Grammar $grammar) => ["alter materialized view {$grammar->wrap($this->table)} set (timescaledb.materialized_only = {$grammar->escape(!$enabled)})"];
+        $this->commands[] = fn (Connection $connection, Grammar $grammar) => ["alter materialized view {$grammar->wrapTable($this->table)} set (timescaledb.materialized_only = {$grammar->escape(!$enabled)})"];
     }
 
     /**


### PR DESCRIPTION
This PR addresses an inconsistency in table prefix handling within the package.

Currently, the `as` method uses the `wrapTable` function to append the database connection prefix to the specified table. However, the `realtime` method did not apply the same logic, which could lead to errors when working with prefixed tables.

This update ensures consistency by also using `wrapTable` within the `realtime` method, aligning its behavior with `as` and preventing prefix-related issues.