### PR TITLE
Support SortDirection in order clauses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^1.5|^2.0",
         "phpunit/phpunit": "^8.5.23|^9.5.13|^10.5|^11.4",
-        "ramsey/uuid": "^3.9|^4.7"
+        "ramsey/uuid": "^3.9|^4.7",
+        "symfony/polyfill-php86": "^1.37"
     },
     "autoload": {
         "psr-4": {

--- a/src/Query/BuilderOrder.php
+++ b/src/Query/BuilderOrder.php
@@ -28,8 +28,10 @@ trait BuilderOrder
         }
 
         $direction = match (true) {
-            \SortDirection::Ascending === $direction || 'asc' === strtolower($direction) => 'asc',
-            \SortDirection::Descending === $direction || 'desc' === strtolower($direction) => 'desc',
+            \SortDirection::Ascending === $direction => 'asc',
+            \SortDirection::Descending === $direction => 'desc',
+            'asc' === strtolower($direction) => 'asc',
+            'desc' === strtolower($direction) => 'desc',
             default => throw new InvalidArgumentException('Order direction must be a SortDirection, "asc" or "desc".'),
         };
 

--- a/src/Query/BuilderOrder.php
+++ b/src/Query/BuilderOrder.php
@@ -28,12 +28,8 @@ trait BuilderOrder
         }
 
         $direction = match (true) {
-            $direction instanceof \SortDirection => match ($direction) {
-                \SortDirection::Ascending => 'asc',
-                \SortDirection::Descending => 'desc',
-            },
-            'asc' === strtolower($direction) => 'asc',
-            'desc' === strtolower($direction) => 'desc',
+            \SortDirection::Ascending === $direction || 'asc' === strtolower($direction) => 'asc',
+            \SortDirection::Descending === $direction || 'desc' === strtolower($direction) => 'desc',
             default => throw new InvalidArgumentException('Order direction must be a SortDirection, "asc" or "desc".'),
         };
 

--- a/src/Query/BuilderOrder.php
+++ b/src/Query/BuilderOrder.php
@@ -14,7 +14,7 @@ trait BuilderOrder
      * Add an "order by" clause to the query.
      *
      * @param \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Contracts\Database\Query\Expression|string $column
-     * @param 'asc'|'desc' $direction
+     * @param \SortDirection|'asc'|'desc' $direction
      * @param 'default'|'first'|'last' $nulls
      */
     public function orderBy($column, $direction = 'asc', $nulls = 'default'): static
@@ -27,10 +27,15 @@ trait BuilderOrder
             $this->addBinding($bindings, $this->unions ? 'unionOrder' : 'order');
         }
 
-        $direction = strtolower($direction);
-        if (!\in_array($direction, ['asc', 'desc'], true)) {
-            throw new InvalidArgumentException('Order direction must be "asc" or "desc".');
-        }
+        $direction = match (true) {
+            $direction instanceof \SortDirection => match ($direction) {
+                \SortDirection::Ascending => 'asc',
+                \SortDirection::Descending => 'desc',
+            },
+            'asc' === strtolower($direction) => 'asc',
+            'desc' === strtolower($direction) => 'desc',
+            default => throw new InvalidArgumentException('Order direction must be a SortDirection, "asc" or "desc".'),
+        };
 
         $nulls = strtolower($nulls);
         if (!\in_array($nulls, ['default', 'first', 'last'], true)) {
@@ -50,9 +55,9 @@ trait BuilderOrder
      * Add an "order by nulls first" clause to the query.
      *
      * @param \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Contracts\Database\Query\Expression|string $column
-     * @param 'asc'|'desc' $direction
+     * @param \SortDirection|'asc'|'desc' $direction
      */
-    public function orderByNullsFirst($column, string $direction = 'asc'): static
+    public function orderByNullsFirst($column, $direction = 'asc'): static
     {
         return $this->orderBy($column, $direction, 'first');
     }
@@ -61,9 +66,9 @@ trait BuilderOrder
      * Add an "order by nulls last" clause to the query.
      *
      * @param \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Contracts\Database\Query\Expression|string $column
-     * @param 'asc'|'desc' $direction
+     * @param \SortDirection|'asc'|'desc' $direction
      */
-    public function orderByNullsLast($column, string $direction = 'asc'): static
+    public function orderByNullsLast($column, $direction = 'asc'): static
     {
         return $this->orderBy($column, $direction, 'last');
     }

--- a/src/Query/BuilderOrder.php
+++ b/src/Query/BuilderOrder.php
@@ -7,6 +7,7 @@ namespace Tpetry\PostgresqlEnhanced\Query;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Query\Expression;
 use InvalidArgumentException;
+use SortDirection;
 
 trait BuilderOrder
 {
@@ -14,7 +15,7 @@ trait BuilderOrder
      * Add an "order by" clause to the query.
      *
      * @param \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Contracts\Database\Query\Expression|string $column
-     * @param \SortDirection|'asc'|'desc' $direction
+     * @param SortDirection|'asc'|'desc' $direction
      * @param 'default'|'first'|'last' $nulls
      */
     public function orderBy($column, $direction = 'asc', $nulls = 'default'): static
@@ -28,8 +29,8 @@ trait BuilderOrder
         }
 
         $direction = match (true) {
-            \SortDirection::Ascending === $direction => 'asc',
-            \SortDirection::Descending === $direction => 'desc',
+            class_exists(SortDirection::class) && SortDirection::Ascending === $direction => 'asc',
+            class_exists(SortDirection::class) && SortDirection::Descending === $direction => 'desc',
             'asc' === strtolower($direction) => 'asc',
             'desc' === strtolower($direction) => 'desc',
             default => throw new InvalidArgumentException('Order direction must be a SortDirection, "asc" or "desc".'),
@@ -53,7 +54,7 @@ trait BuilderOrder
      * Add an "order by nulls first" clause to the query.
      *
      * @param \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Contracts\Database\Query\Expression|string $column
-     * @param \SortDirection|'asc'|'desc' $direction
+     * @param SortDirection|'asc'|'desc' $direction
      */
     public function orderByNullsFirst($column, $direction = 'asc'): static
     {
@@ -64,7 +65,7 @@ trait BuilderOrder
      * Add an "order by nulls last" clause to the query.
      *
      * @param \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Contracts\Database\Query\Expression|string $column
-     * @param \SortDirection|'asc'|'desc' $direction
+     * @param SortDirection|'asc'|'desc' $direction
      */
     public function orderByNullsLast($column, $direction = 'asc'): static
     {

--- a/tests/Query/OrderTest.php
+++ b/tests/Query/OrderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tpetry\PostgresqlEnhanced\Tests\Query;
 
+use Composer\Semver\Comparator;
 use Tpetry\PostgresqlEnhanced\Tests\TestCase;
 
 class OrderTest extends TestCase
@@ -52,6 +53,10 @@ class OrderTest extends TestCase
 
     public function testSortDirectionEnum(): void
     {
+        if (Comparator::lessThan(\PHP_VERSION, '8.1.0')) {
+            $this->markTestSkipped('Enums are only supported from PHP 8.1.0.');
+        }
+
         $this->getConnection()->unprepared('CREATE TABLE example (col int)');
 
         $queries = $this->withQueryLog(function (): void {

--- a/tests/Query/OrderTest.php
+++ b/tests/Query/OrderTest.php
@@ -50,6 +50,40 @@ class OrderTest extends TestCase
         );
     }
 
+    public function testSortDirectionEnum(): void
+    {
+        if (!\function_exists('enum_exists') || !enum_exists(\SortDirection::class)) {
+            $this->markTestSkipped('The SortDirection enum is not available.');
+        }
+
+        $this->getConnection()->unprepared('CREATE TABLE example (id int, col int, created_at timestamp)');
+
+        $queries = $this->withQueryLog(function (): void {
+            $this->getConnection()->table('example')->orderBy('col', \SortDirection::Ascending)->get();
+            $this->getConnection()->table('example')->orderBy('col', \SortDirection::Descending, nulls: 'last')->get();
+            $this->getConnection()->table('example')->orderByNullsFirst('col', \SortDirection::Descending)->get();
+            $this->getConnection()->table('example')->latest('created_at')->get();
+            $this->getConnection()->table('example')->oldest('created_at')->get();
+            $this->getConnection()->table('example')->orderByDesc('col')->get();
+            $this->getConnection()->table('example')->forPageBeforeId(10, 20)->get();
+            $this->getConnection()->table('example')->forPageAfterId(10, 20)->get();
+        });
+
+        $this->assertEquals(
+            [
+                'select * from "example" order by "col" asc',
+                'select * from "example" order by "col" desc nulls last',
+                'select * from "example" order by "col" desc nulls first',
+                'select * from "example" order by "created_at" desc',
+                'select * from "example" order by "created_at" asc',
+                'select * from "example" order by "col" desc',
+                'select * from "example" where "id" < ? order by "id" desc limit 10',
+                'select * from "example" where "id" > ? order by "id" asc limit 10',
+            ],
+            array_column($queries, 'query'),
+        );
+    }
+
     public function testVectorSimilarity(): void
     {
         if (!$this->getConnection()->table('pg_available_extensions')->where('name', 'vector')->exists()) {

--- a/tests/Query/OrderTest.php
+++ b/tests/Query/OrderTest.php
@@ -52,33 +52,25 @@ class OrderTest extends TestCase
 
     public function testSortDirectionEnum(): void
     {
-        if (!\function_exists('enum_exists') || !enum_exists(\SortDirection::class)) {
-            $this->markTestSkipped('The SortDirection enum is not available.');
-        }
-
-        $this->getConnection()->unprepared('CREATE TABLE example (id int, col int, created_at timestamp)');
+        $this->getConnection()->unprepared('CREATE TABLE example (col int)');
 
         $queries = $this->withQueryLog(function (): void {
             $this->getConnection()->table('example')->orderBy('col', \SortDirection::Ascending)->get();
-            $this->getConnection()->table('example')->orderBy('col', \SortDirection::Descending, nulls: 'last')->get();
+            $this->getConnection()->table('example')->orderBy('col', \SortDirection::Descending)->get();
+            $this->getConnection()->table('example')->orderByNullsFirst('col', \SortDirection::Ascending)->get();
             $this->getConnection()->table('example')->orderByNullsFirst('col', \SortDirection::Descending)->get();
-            $this->getConnection()->table('example')->latest('created_at')->get();
-            $this->getConnection()->table('example')->oldest('created_at')->get();
-            $this->getConnection()->table('example')->orderByDesc('col')->get();
-            $this->getConnection()->table('example')->forPageBeforeId(10, 20)->get();
-            $this->getConnection()->table('example')->forPageAfterId(10, 20)->get();
+            $this->getConnection()->table('example')->orderByNullsLast('col', \SortDirection::Ascending)->get();
+            $this->getConnection()->table('example')->orderByNullsLast('col', \SortDirection::Descending)->get();
         });
 
         $this->assertEquals(
             [
                 'select * from "example" order by "col" asc',
-                'select * from "example" order by "col" desc nulls last',
-                'select * from "example" order by "col" desc nulls first',
-                'select * from "example" order by "created_at" desc',
-                'select * from "example" order by "created_at" asc',
                 'select * from "example" order by "col" desc',
-                'select * from "example" where "id" < ? order by "id" desc limit 10',
-                'select * from "example" where "id" > ? order by "id" asc limit 10',
+                'select * from "example" order by "col" asc nulls first',
+                'select * from "example" order by "col" desc nulls first',
+                'select * from "example" order by "col" asc nulls last',
+                'select * from "example" order by "col" desc nulls last',
             ],
             array_column($queries, 'query'),
         );


### PR DESCRIPTION
## Summary

- normalize Laravel 13.8's global `SortDirection` enum in the PostgreSQL enhanced query `orderBy()` override
- allow the package-specific nulls ordering helpers to pass `SortDirection` through to `orderBy()`
- add coverage for direct enum ordering plus Laravel helper paths that now pass enum directions (`latest`, `oldest`, `orderByDesc`, `forPageBeforeId`, `forPageAfterId`)

## Context

Laravel 13.8 added support for `SortDirection` in query builder order methods in laravel/framework#59865. Because this package overrides `orderBy()` and lowercases the direction directly, framework helpers can now pass `SortDirection::Ascending` / `SortDirection::Descending` into `strtolower()`, causing a TypeError.

This keeps the package's string defaults for compatibility with older supported PHP/Laravel versions, but maps `SortDirection` cases to the same stored `asc` / `desc` strings Laravel uses internally.

Fixes #132.

## Testing

- `vendor\\bin\\testbench package:test --no-coverage --filter OrderTest`
- `vendor\\bin\\testbench package:test --no-coverage` *(427 passed, 4 skipped, 1 existing timeout-sensitive migration test failed: `ZeroDowntimeMigrationTest::timeout is reset for every migration`)*
- `php -l src\\Query\\BuilderOrder.php`
- `php -l tests\\Query\\OrderTest.php`